### PR TITLE
Reorder funcion calls to prevent score loss

### DIFF
--- a/weave/Scripts/Main.cs
+++ b/weave/Scripts/Main.cs
@@ -221,10 +221,11 @@ public partial class Main : Node2D
     {
         _roundCompletions = 0;
 
+        _scoreDisplay.OnRoundComplete();
+
         DisablePlayerMovement();
         ClearLinesAndSegments();
         ClearAndSpawnGoals();
-        _scoreDisplay.OnRoundComplete();
     }
 
     private void ClearLinesAndSegments()


### PR DESCRIPTION
In the previous order on-round-end scores were not added (the function _scoreDisplay.OnRoundComplete() exits immediately because _scoreDisplay is disabled in DisablePlayerMovement())