### PR TITLE
Collision zoom

### DIFF
--- a/weave/Menus/StartScreen.tscn
+++ b/weave/Menus/StartScreen.tscn
@@ -5,12 +5,12 @@
 [ext_resource type="PackedScene" uid="uid://13krjegt6uqn" path="res://Objects/Firefly.tscn" id="3_r76ru"]
 [ext_resource type="Theme" uid="uid://dd7rckhjid75d" path="res://Themes/weave_theme.tres" id="4_8y3os"]
 [ext_resource type="Texture2D" uid="uid://8rd510i1ect" path="res://Assets/bg_pattern.png" id="4_cecwe"]
-[ext_resource type="PackedScene" path="res://UI/Blur.tscn" id="4_v148g"]
+[ext_resource type="PackedScene" uid="uid://cgb58y31ghkln" path="res://UI/Blur.tscn" id="4_v148g"]
 [ext_resource type="Texture2D" uid="uid://b0km2s34ci8e3" path="res://Assets/Icons/play-circle.svg" id="5_76tk4"]
 [ext_resource type="Texture2D" uid="uid://djtchdeox7xxd" path="res://Assets/Icons/adjustments-horizontal.svg" id="6_bndfp"]
 [ext_resource type="Texture2D" uid="uid://devx10rh1eqbt" path="res://Assets/Icons/arrow-right-on-rectangle.svg" id="7_6tkco"]
 [ext_resource type="AudioStream" uid="uid://ccog5qwbsdqj0" path="res://Assets/Music/beginning.mp3" id="10_4fvpc"]
-[ext_resource type="PackedScene" path="res://Objects/Glowifier.tscn" id="10_hkd0d"]
+[ext_resource type="PackedScene" uid="uid://y8csparp0kpv" path="res://Objects/Glowifier.tscn" id="10_hkd0d"]
 
 [sub_resource type="StyleBoxLine" id="StyleBoxLine_y8k07"]
 color = Color(1, 0.164706, 0.427451, 0.392157)

--- a/weave/Scenes/Main.tscn
+++ b/weave/Scenes/Main.tscn
@@ -1,12 +1,13 @@
-[gd_scene load_steps=11 format=3 uid="uid://do2omcqx18vk6"]
+[gd_scene load_steps=12 format=3 uid="uid://do2omcqx18vk6"]
 
 [ext_resource type="Script" path="res://Scripts/Main.cs" id="1_x7cvk"]
 [ext_resource type="AudioStream" uid="uid://c1v30d3rogeso" path="res://Assets/Music/weave.mp3" id="4_4yh78"]
 [ext_resource type="PackedScene" uid="uid://dfn3svkimd3s4" path="res://UI/GameOverOverlay.tscn" id="4_lq1d2"]
 [ext_resource type="FontFile" uid="uid://c3a6bjpr2ppwy" path="res://Assets/Fonts/Open_Sans/static/OpenSans-ExtraBold.ttf" id="5_1pvgl"]
 [ext_resource type="PackedScene" uid="uid://d1s5px2gej6oj" path="res://UI/ScoreDisplay.tscn" id="6_6l1qm"]
-[ext_resource type="PackedScene" path="res://Objects/Glowifier.tscn" id="7_trvja"]
+[ext_resource type="PackedScene" uid="uid://y8csparp0kpv" path="res://Objects/Glowifier.tscn" id="7_trvja"]
 [ext_resource type="AudioStream" uid="uid://c4yf6ykqyp4rd" path="res://Assets/SFX/complete.mp3" id="7_wjcpy"]
+[ext_resource type="Script" path="res://Scripts/Camera.cs" id="8_npgvn"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_wip0u"]
 font = ExtResource("5_1pvgl")
@@ -95,3 +96,8 @@ autoplay = true
 [node name="ClearedLevelPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("7_wjcpy")
 volume_db = -10.311
+
+[node name="Camera" type="Camera2D" parent="."]
+position = Vector2(800, 450)
+ignore_rotation = false
+script = ExtResource("8_npgvn")

--- a/weave/Scripts/Camera.cs
+++ b/weave/Scripts/Camera.cs
@@ -1,11 +1,13 @@
 using Godot;
 using GodotSharper;
 
+namespace Weave;
+
 public partial class Camera : Camera2D
 {
-    private Vector2 _desiredPosition = new(800, 450);
-    private Vector2 _desiredZoom = new(1, 1);
-    private float _desiredRotation = 0;
+    private Vector2 _desiredPosition;
+    private Vector2 _desiredZoom;
+    private float _desiredRotation;
     private float _desiredLerpStrength = 3f;
     private float _lerpStrength = 3f;
 

--- a/weave/Scripts/Camera.cs
+++ b/weave/Scripts/Camera.cs
@@ -1,0 +1,46 @@
+using Godot;
+using GodotSharper;
+
+public partial class Camera : Camera2D
+{
+    private Vector2 _desiredPosition = new(800, 450);
+    private Vector2 _desiredZoom = new(1, 1);
+    private float _desiredRotation = 0;
+    private float _desiredLerpStrength = 3f;
+    private float _lerpStrength = 3f;
+
+    public override void _Ready()
+    {
+        Reset();
+    }
+
+    public override void _Process(double delta)
+    {
+        Position = Position.Lerp(_desiredPosition, (float)delta * _lerpStrength);
+        Zoom = Zoom.Lerp(_desiredZoom, (float)delta * _lerpStrength);
+        Rotation = Mathf.Lerp(Rotation, _desiredRotation, (float)delta * _lerpStrength);
+        _lerpStrength = Mathf.Lerp(_lerpStrength, _desiredLerpStrength, (float)delta * 0.01f);
+    }
+
+    private void Reset()
+    {
+        _desiredPosition = new(800, 450);
+        _desiredZoom = new(1, 1);
+        _desiredRotation = 0;
+    }
+
+    public void OnGameOver(Vector2 collisionPosition)
+    {
+        _desiredPosition = collisionPosition;
+        _desiredRotation = 0.3f;
+        _desiredZoom = new(2f, 2f);
+
+        AddChild(
+            TimerFactory.StartedSelfDestructingOneShot(3, () =>
+            {
+                _lerpStrength = 0f;
+                Reset();
+            })
+        );
+    }
+}

--- a/weave/Scripts/Main.cs
+++ b/weave/Scripts/Main.cs
@@ -35,6 +35,9 @@ public partial class Main : Node2D
     [GetNode("GameOverOverlay")]
     private GameOverOverlay _gameOverOverlay;
 
+    [GetNode("Camera")]
+    private Camera _camera;
+
     [GetNode("ScoreDisplay")]
     private ScoreDisplay _scoreDisplay;
 
@@ -156,8 +159,6 @@ public partial class Main : Node2D
 
     private void DetectPlayerCollision()
     {
-        var hasCollided = false;
-
         // Perform collision detection for players that are drawing
         foreach (var player in _players.Where(player => player.CurveSpawner.IsDrawing))
         {
@@ -166,11 +167,11 @@ public partial class Main : Node2D
                 player.GetRadius()
             );
             if (IsPlayerIntersecting(player, segments))
-                hasCollided = true;
+            {
+                GameOver(player.Position);
+                break;
+            }
         }
-
-        if (hasCollided)
-            GameOver();
     }
 
     private void DetectPlayerOutOfBounds()
@@ -189,12 +190,13 @@ public partial class Main : Node2D
         }
     }
 
-    private void GameOver()
+    private void GameOver(Vector2 collisionPosition)
     {
         _gameIsRunning = false;
         SetPlayerMovement(false);
         SetPlayerTurning(false);
-        _scoreDisplay.OnGameEnd();
+        _scoreDisplay.OnGameOver();
+        _camera.OnGameOver(collisionPosition);
         _gameOverOverlay.DisplayGameOver();
         _audioStreamPlayer.PitchScale = 0.5f;
 
@@ -355,7 +357,7 @@ public partial class Main : Node2D
             obstacle.BodyEntered += node =>
             {
                 if (node is not Player) return;
-                GameOver();
+                GameOver(node.Position);
             };
 
             CallDeferred("add_child", obstacle);

--- a/weave/Scripts/ScoreDisplay.cs
+++ b/weave/Scripts/ScoreDisplay.cs
@@ -118,7 +118,7 @@ public partial class ScoreDisplay : CanvasLayer
         _playerCount = playerCount;
     }
 
-    public void OnGameEnd()
+    public void OnGameOver()
     {
         Enabled = false;
         _animationPlayer.Play("ScoreDisplayEnd");

--- a/weave/UI/GameOverOverlay.tscn
+++ b/weave/UI/GameOverOverlay.tscn
@@ -1,11 +1,11 @@
 [gd_scene load_steps=8 format=3 uid="uid://dfn3svkimd3s4"]
 
 [ext_resource type="Script" path="res://Scripts/MenuControllers/GameOverOverlay.cs" id="1_xbr3w"]
-[ext_resource type="Theme" uid="uid://by2pot0p04k5c" path="res://Themes/weave_theme.tres" id="2_5xrrk"]
+[ext_resource type="Theme" uid="uid://dd7rckhjid75d" path="res://Themes/weave_theme.tres" id="2_5xrrk"]
 [ext_resource type="Texture2D" uid="uid://b0km2s34ci8e3" path="res://Assets/Icons/play-circle.svg" id="3_0cm3s"]
 [ext_resource type="FontFile" uid="uid://cubowpt0beb6k" path="res://Assets/Fonts/Open_Sans/static/OpenSans-Bold.ttf" id="3_aqw47"]
 [ext_resource type="Texture2D" uid="uid://devx10rh1eqbt" path="res://Assets/Icons/arrow-right-on-rectangle.svg" id="4_ci4ui"]
-[ext_resource type="AudioStream" path="res://Assets/SFX/explosion.mp3" id="6_3if2j"]
+[ext_resource type="AudioStream" uid="uid://drclr0x038ndn" path="res://Assets/SFX/explosion.mp3" id="6_3if2j"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_rm0a5"]
 font = ExtResource("3_aqw47")
@@ -27,9 +27,9 @@ anchors_preset = 5
 anchor_left = 0.5
 anchor_right = 0.5
 offset_left = -292.0
-offset_top = 350.0
+offset_top = 220.0
 offset_right = 292.0
-offset_bottom = 710.0
+offset_bottom = 780.0
 grow_horizontal = 2
 
 [node name="VBox" type="VBoxContainer" parent="CenterContainer"]
@@ -46,7 +46,7 @@ horizontal_alignment = 1
 [node name="HSeparator" type="HSeparator" parent="CenterContainer/VBox"]
 modulate = Color(1, 1, 1, 0)
 self_modulate = Color(1, 1, 1, 0)
-custom_minimum_size = Vector2(0, 40)
+custom_minimum_size = Vector2(0, 200)
 layout_mode = 2
 
 [node name="CenterContainer" type="CenterContainer" parent="CenterContainer/VBox"]

--- a/weave/UI/ScoreDisplay.tscn
+++ b/weave/UI/ScoreDisplay.tscn
@@ -7,34 +7,6 @@
 font = ExtResource("2_8chhu")
 font_size = 100
 
-[sub_resource type="Animation" id="Animation_icbo7"]
-resource_name = "ScoreDisplayShine"
-length = 2.0
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("..:scale")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0, 0.2, 1, 1.1, 1.3, 2),
-"transitions": PackedFloat32Array(3, 0.333, 0.33, 3, 7, 7),
-"update": 0,
-"values": [Vector2(0.4, 0.4), Vector2(0.6, 0.6), Vector2(0.9, 0.9), Vector2(1, 1), Vector2(0.9, 0.9), Vector2(0.4, 0.4)]
-}
-tracks/1/type = "value"
-tracks/1/imported = false
-tracks/1/enabled = false
-tracks/1/path = NodePath(".:modulate")
-tracks/1/interp = 1
-tracks/1/loop_wrap = true
-tracks/1/keys = {
-"times": PackedFloat32Array(0, 1, 1.1, 1.5),
-"transitions": PackedFloat32Array(3, 1, 1, 1),
-"update": 0,
-"values": [Color(1, 1, 1, 1), Color(1, 1, 1, 1), Color(1, 0.901961, 0.294118, 1), Color(1, 1, 1, 1)]
-}
-
 [sub_resource type="Animation" id="Animation_0skkr"]
 length = 0.001
 
@@ -63,7 +35,7 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0, 1),
 "transitions": PackedFloat32Array(0.2, 7),
 "update": 0,
-"values": [Vector2(300, 0), Vector2(300, 150)]
+"values": [Vector2(300, 0), Vector2(300, 80)]
 }
 tracks/2/type = "value"
 tracks/2/imported = false
@@ -88,6 +60,34 @@ tracks/3/keys = {
 "transitions": PackedFloat32Array(2, 0.3, 1),
 "update": 0,
 "values": [Color(1, 1, 1, 0), Color(1, 1, 1, 0.541176), Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_icbo7"]
+resource_name = "ScoreDisplayShine"
+length = 2.0
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("..:scale")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.2, 1, 1.1, 1.3, 2),
+"transitions": PackedFloat32Array(3, 0.333, 0.33, 3, 7, 7),
+"update": 0,
+"values": [Vector2(0.4, 0.4), Vector2(0.6, 0.6), Vector2(0.9, 0.9), Vector2(1, 1), Vector2(0.9, 0.9), Vector2(0.4, 0.4)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = false
+tracks/1/path = NodePath(".:modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 1, 1.1, 1.5),
+"transitions": PackedFloat32Array(3, 1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 1), Color(1, 1, 1, 1), Color(1, 0.901961, 0.294118, 1), Color(1, 1, 1, 1)]
 }
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_irjnc"]
@@ -130,9 +130,9 @@ anchors_preset = 5
 anchor_left = 0.5
 anchor_right = 0.5
 offset_left = -77.0
-offset_top = 128.0
+offset_top = 58.0
 offset_right = 77.0
-offset_bottom = 198.0
+offset_bottom = 128.0
 grow_horizontal = 2
 
 [node name="Label" type="Label" parent="CenterContainer2"]


### PR DESCRIPTION
Added a zoom on game-over:
- Added a camera that zooms, positions and rotates on the collision, then slowly transforms back to the initial values
- Reordered the game-over-overlay to make the middle part more empty, allowing players to see the zoomed collision